### PR TITLE
[f] option to run public stream or user stream

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -59,8 +59,8 @@ The bot should now receive tweets containing 'Donald Trump' or tweets posted by 
 
 Handler
 -------
-This is where you handle incoming tweet. For more information, see `handler reference <reference/responsebot.handlers.base.html>`_.
+For a list of methods you can define in your custom handlers, see `handler reference <reference/responsebot.handlers.base.html>`_.
 
-Client
-------
-We support a client to perform twitter actions like create, delete a tweet. For full list of supported actions, please look at the `client reference <reference/responsebot.responsebot_client.html>`_.
+Reply to tweets
+---------------
+You can reply to received tweets, see more in the `tutorial's client section <tutorial.html#client>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Contents:
 
    getting_started
    tutorial
+   streams_and_filters
    reference
 
 Indices and tables

--- a/docs/streams_and_filters.rst
+++ b/docs/streams_and_filters.rst
@@ -1,0 +1,40 @@
+Streams and filters
+===================
+
+Streams
+-------
+
+Twitter has `three stream APIs <https://dev.twitter.com/streaming/overview>`_ to listen to. ResponseBot currently
+implement the public stream and user stream listening methods. By default the bot listen to public stream, you can tell
+the bot to listen to user stream by setting it in the config file:
+
+.. code-block:: ini
+
+   [stream]
+   user_stream=true
+
+or pass in a flag in the start command:
+
+.. code-block:: bash
+
+   $ start_responsebot --user-stream
+
+Filters
+-------
+
+The public stream utilize two parameters: :code:`track` and :code:`follow`, to filter global streams (you cannot listen
+to every tweets in the world, you must have either 1 keyword to track or 1 user to follow). You provide these parameters
+in your handlers' :code:`get_filter` method as follow:
+
+.. code-block:: python
+
+   def get_filter(self):
+       return TweetFilter(track=['keyword'], follow=['user_id'])
+
+By default the `BaseTweetHandler <reference/responsebot.handlers.base.html#responsebot.handlers.base.BaseTweetHandler>`_
+returns a filter with the :code:`follow` parameter set as the bot's authenticated user and an empty :code:`track`
+parameter, which is equivalent to running the bot with :code:`user_stream` and provide no :code:`track` in your
+handlers.
+
+The :code:`follow` parameter will not be used if you use :code:`user_stream`. See more about
+`TweetFilter <reference/responsebot.models.html#responsebot.models.TweetFilter>`_

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -32,12 +32,31 @@ Otherwise it should show an error
 
      [ERROR] 2016-05-04 10:52:17 Could not authenticate.
 
+You can pass the credentials as a :code:`start_responsebot`'s option instead of using a config file:
+
+.. code-block:: bash
+
+   $ start_responsebot --auth <consumer_key> <consumer_secret> <token_key> <token_secret>
+
+Listen to public stream or user stream
+--------------------------------------
+
+The bot can listen to every tweets in the world (that match some keywords) or it can listen to its authenticated user's
+timeline, as if it is that user. By default, the bot listen to the public stream, you can tell it to listen to the user
+stream as follow:
+
+.. code-block:: bash
+
+   $ start_responsebot --user-stream
+
+See more about stream and filters `here <streams_and_filters.html>`_.
+
 Handler
 -------
 
 To receive an incoming tweet, you need to subclass :code:`BaseTweetHandler` and implement the :code:`on_tweet` method.
 You can specify what kind of tweets the bot should listen to by returning an appropriate
-`TweetFilter <reference/responsebot.models.html#TweetFilter>`_ in the :code:`get_filter` method.
+`TweetFilter <reference/responsebot.models.html#responsebot.models.TweetFilter>`_ in the :code:`get_filter` method.
 
 .. code-block:: python
 
@@ -45,7 +64,10 @@ You can specify what kind of tweets the bot should listen to by returning an app
        def on_tweet(self, tweet):
            print('Received tweet: %s from %s' % (tweet.text, tweet.user.screen_name))
 
-See what :code:`tweet` object contains in `reference <reference/responsebot.models.html#Tweet>`_.
+       def get_filter(self):
+        return TweetFilter(track=['Donald Trump'], follow=['<your personal Twitter id>'])
+
+See what :code:`tweet` object contains in `reference <reference/responsebot.models.html#responsebot.models.Tweet>`_.
 
 Client
 ------

--- a/responsebot/handlers/base.py
+++ b/responsebot/handlers/base.py
@@ -17,7 +17,14 @@ class BaseTweetHandler(object):
 
     def get_filter(self):
         """
-        Override this method for custom filter
+        Override this method for custom filter. By default returns a filter with the bot's authenticated user ID in the
+        follow list.
+
+        Example:
+
+        .. code-block:: python
+
+           return TweetFilter(track=['hello'], follow=['<some_user_id>'])`
         """
         return TweetFilter(follow=[str(self.client.get_current_user().id)])
 

--- a/responsebot/models.py
+++ b/responsebot/models.py
@@ -63,6 +63,12 @@ class TweetFilter(object):
     Define criteria to filter tweets from Twitter's public stream. See `track` and `follow` parameters in `here <https://dev.twitter.com/streaming/overview/request-parameters>`_.
     """
     def __init__(self, track=[], follow=[]):
+        """
+
+        :param track: A list of keywords to follow (each could also be a @mention or a #hashtag)
+        :param follow: A list of user ID strings to follow
+        :return:
+        """
         self.track = track
         self.follow = follow
 
@@ -81,10 +87,8 @@ class TweetFilter(object):
 
         user_mentions = [x['id'] for x in tweet.entities.get('user_mentions', [])]
         for value in self.follow:
-            if tweet.user.id == int(value):
-                return True
-
-            if int(value) in user_mentions:
+            int_value = int(value)
+            if tweet.user.id == int_value or int_value in user_mentions:
                 return True
 
         return False

--- a/responsebot/responsebot.py
+++ b/responsebot/responsebot.py
@@ -62,7 +62,7 @@ class ResponseBot(object):
         try:
             listener = ResponseBotListener(client=client, handler_classes=handler_classes)
 
-            stream = ResponseBotStream(client=client, listener=listener)
+            stream = ResponseBotStream(client=client, listener=listener, user_stream=self.config.get('user_stream'))
             stream.start()
         except UserHandlerError as e:
             # TODO: print only stack trace from user exception

--- a/responsebot/start_responsebot.py
+++ b/responsebot/start_responsebot.py
@@ -12,6 +12,7 @@ dotenv.load_dotenv('.env')
 
 @click.command()
 @click.option('--handlers-package', help='Path to package containing all your handlers')
+@click.option('--auth', nargs=4, help='Authentication credentials')
 def main(*args, **kwargs):
     """Run responsebot"""
     # TODO: validate options

--- a/responsebot/start_responsebot.py
+++ b/responsebot/start_responsebot.py
@@ -13,6 +13,7 @@ dotenv.load_dotenv('.env')
 @click.command()
 @click.option('--handlers-package', help='Path to package containing all your handlers')
 @click.option('--auth', nargs=4, help='Authentication credentials')
+@click.option('--user-stream', is_flag=True, default=False, help='Whether to use Twitter\'s public or user stream')
 def main(*args, **kwargs):
     """Run responsebot"""
     # TODO: validate options

--- a/responsebot/utils/config_utils.py
+++ b/responsebot/utils/config_utils.py
@@ -45,14 +45,15 @@ class ResponseBotConfig(object):
         :param dict kwargs: CLI options
         """
         self._load_config_from_cli_argument(key='handlers_package', **kwargs)
-        self._load_config_from_cli_argument(key='consumer_key', **kwargs)
-        self._load_config_from_cli_argument(key='consumer_secret', **kwargs)
-        self._load_config_from_cli_argument(key='token_key', **kwargs)
-        self._load_config_from_cli_argument(key='token_secret', **kwargs)
+        self._load_config_from_cli_argument(key='auth', **kwargs)
 
     def _load_config_from_cli_argument(self, key, **kwargs):
         if kwargs.get(key):
-            self._config[key] = kwargs.get(key)
+            if key == 'auth':
+                self._config['consumer_key'], self._config['consumer_secret'],\
+                self._config['token_key'], self._config['token_secret'] = kwargs.get(key)
+            else:
+                self._config[key] = kwargs.get(key)
 
     def validate_configs(self):
         """

--- a/responsebot/utils/config_utils.py
+++ b/responsebot/utils/config_utils.py
@@ -38,6 +38,11 @@ class ResponseBotConfig(object):
             self._config['token_key'] = config_parser.get('auth', 'token_key')
             self._config['token_secret'] = config_parser.get('auth', 'token_secret')
 
+        if config_parser.has_section('stream'):
+            self._config['user_stream'] = config_parser.get('stream', 'user_stream').lower() == 'true'
+        else:
+            self._config['user_stream'] = False
+
     def load_config_from_cli_arguments(self, *args, **kwargs):
         """
         Get config values of passed in CLI options.
@@ -46,6 +51,7 @@ class ResponseBotConfig(object):
         """
         self._load_config_from_cli_argument(key='handlers_package', **kwargs)
         self._load_config_from_cli_argument(key='auth', **kwargs)
+        self._load_config_from_cli_argument(key='user_stream', **kwargs)
 
     def _load_config_from_cli_argument(self, key, **kwargs):
         if kwargs.get(key):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # - MAJOR version when they make incompatible API changes,
     # - MINOR version when they add functionality in a backwards-compatible manner, and
     # - MAINTENANCE version when they make backwards-compatible bug fixes.
-    version='0.2.1',
+    version='0.2.2',
 
     description='Automatically response to any tweets mentioning you',
 

--- a/tests/integration_tests/test_start_responsebot_command.py
+++ b/tests/integration_tests/test_start_responsebot_command.py
@@ -19,8 +19,16 @@ class StartResponseBotCommandTestCase(TestCase):
 
     def test_call_command_with_handlers_module_option(self):
         handlers_package = 'handlers_package'
+        consumer_key = 'ck'
+        consumer_secret = 'cs'
+        token_key = 'tk'
+        token_secret = 'ts'
 
         with patch('responsebot.start_responsebot.ResponseBot.__init__') as mock_responsebot:
-            CliRunner().invoke(cli=start_responsebot.main, args=['--handlers-package', handlers_package])
+            CliRunner().invoke(cli=start_responsebot.main, args=[
+                '--handlers-package', handlers_package,
+                '--auth', consumer_key, consumer_secret, token_key, token_secret,
+            ])
 
-            mock_responsebot.assert_called_once_with(handlers_package=handlers_package)
+            mock_responsebot.assert_called_once_with(auth=(consumer_key, consumer_secret, token_key, token_secret),
+                                                     handlers_package=handlers_package)

--- a/tests/integration_tests/test_start_responsebot_command.py
+++ b/tests/integration_tests/test_start_responsebot_command.py
@@ -31,4 +31,4 @@ class StartResponseBotCommandTestCase(TestCase):
             ])
 
             mock_responsebot.assert_called_once_with(auth=(consumer_key, consumer_secret, token_key, token_secret),
-                                                     handlers_package=handlers_package)
+                                                     handlers_package=handlers_package, user_stream=False)

--- a/tests/unit_tests/test_responsebot.py
+++ b/tests/unit_tests/test_responsebot.py
@@ -24,16 +24,13 @@ class ResponseBotTestCase(TestCase):
                 patch('responsebot.responsebot.ResponseBotStream') as mock_stream:
             ResponseBot(
                 handlers_package='some_package',
-                consumer_key='ck',
-                consumer_secret='cs',
-                token_key='tk',
-                token_secret='ts'
+                auth=('ck', 'cs', 'tk', 'ts'),
             ).start()
 
             self.assertTrue(mock_auth.called)
             self.assertTrue(mock_discover.called)
             mock_listener.assert_called_once_with(client=client, handler_classes=handler_classes)
-            mock_stream.assert_called_once_with(client=client, listener=listener)
+            mock_stream.assert_called_once_with(client=client, listener=listener, user_stream=False)
             mock_stream().start.assert_called_once_with()
 
     @patch('logging.error')

--- a/tests/unit_tests/test_tweet_stream.py
+++ b/tests/unit_tests/test_tweet_stream.py
@@ -14,7 +14,7 @@ except ImportError:
 class TweetStreamTestCase(TestCase):
     @patch('responsebot.responsebot_stream.tweepy.Stream.filter', side_effect=TweepError(reason='some mild error'))
     def test_retry_on_non_critical_error(self, mock_stream):
-        stream = ResponseBotStream(client=MagicMock(client=MagicMock()), listener=MagicMock())
+        stream = ResponseBotStream(client=MagicMock(client=MagicMock()), listener=MagicMock(), user_stream=False)
         stream.start(retry_limit=1)
 
         self.assertEqual(mock_stream.call_count, 2)
@@ -22,7 +22,7 @@ class TweetStreamTestCase(TestCase):
     def test_terminate_on_critical_error(self):
         exception = TweepError(reason='Stream object already connected!')
         with patch('responsebot.responsebot_stream.tweepy.Stream.filter', side_effect=exception) as mock_stream:
-            stream = ResponseBotStream(client=MagicMock(client=MagicMock()), listener=MagicMock())
+            stream = ResponseBotStream(client=MagicMock(client=MagicMock()), listener=MagicMock(), user_stream=False)
 
             self.assertRaises(APIError, stream.start)
             self.assertEqual(mock_stream.call_count, 1)
@@ -30,9 +30,19 @@ class TweetStreamTestCase(TestCase):
     def test_filter_using_merged_filter(self):
         merged_filter = MagicMock(track=['track'], follow=['follow'])
         stream = ResponseBotStream(client=MagicMock(client=MagicMock()), listener=MagicMock(
-                get_merged_filter=MagicMock(return_value=merged_filter)))
+                get_merged_filter=MagicMock(return_value=merged_filter)), user_stream=False)
 
         with patch('responsebot.responsebot_stream.tweepy.Stream.filter') as mock_filter_call:
             stream.start(retry_limit=0)
 
             mock_filter_call.assert_called_once_with(track=merged_filter.track, follow=merged_filter.follow)
+
+    def test_use_user_stream(self):
+        merged_filter = MagicMock(track=['track'])
+        stream = ResponseBotStream(client=MagicMock(client=MagicMock()), listener=MagicMock(
+                get_merged_filter=MagicMock(return_value=merged_filter)), user_stream=True)
+
+        with patch('responsebot.responsebot_stream.tweepy.Stream.userstream') as mock_user_stream_call:
+            stream.start(retry_limit=0)
+
+            mock_user_stream_call.assert_called_once_with(track=merged_filter.track)

--- a/tests/unit_tests/utils/test_config_utils.py
+++ b/tests/unit_tests/utils/test_config_utils.py
@@ -17,10 +17,7 @@ class ConfigUtilsTestCase(TestCase):
     def test_validate_config(self):
         params = {
             'handlers_package': 'handlers_package',
-            'consumer_key': 'consumer_key',
-            'consumer_secret': 'consumer_secret',
-            'token_key': 'token_key',
-            'token_secret': 'token_secret',
+            'auth': ('consumer_key', 'consumer_secret', 'token_key', 'token_secret'),
         }
         try:
             ResponseBotConfig(**params)

--- a/tests/unit_tests/utils/test_config_utils.py
+++ b/tests/unit_tests/utils/test_config_utils.py
@@ -40,10 +40,7 @@ class ConfigUtilsTestCase(TestCase):
     def test_load_config_from_terminal(self, mock_1, mock_2):
         params = {
             'handlers_package': 'handlers_package',
-            'consumer_key': 'consumer_key',
-            'consumer_secret': 'consumer_secret',
-            'token_key': 'token_key',
-            'token_secret': 'token_secret',
+            'auth': ('consumer_key', 'consumer_secret', 'token_key', 'token_secret'),
         }
 
         config = ResponseBotConfig(**params)


### PR DESCRIPTION
## Description
- By default, the bot will listen on the public stream of twitter. Developer can pass an argument `--user-stream` to have the bot listen on user stream. More information [here](https://dev.twitter.com/streaming/overview)
- Developer can now pass credentials in CLI argument by `--auth <consumer_key> <consumer_secret> <token_key> <token_secret>`
