### PR TITLE
[f] unfollow method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 click==6.6
 coverage==4.0.3
-python-dotenv==0.4.0
 oauthlib==1.0.3
 pluggy==0.3.1
 py==1.4.31

--- a/responsebot/responsebot_client.py
+++ b/responsebot/responsebot_client.py
@@ -65,7 +65,7 @@ class ResponseBotClient(object):
         :param text: the text to post
         :return: Tweet object
         """
-        return Tweet(self._client.update_status(text)._json)
+        return Tweet(self._client.update_status(status=text)._json)
 
     def retweet(self, id):
         """
@@ -75,7 +75,7 @@ class ResponseBotClient(object):
         :return: True if success, False otherwise
         """
         try:
-            self._client.retweet(id)
+            self._client.retweet(id=id)
             return True
         except TweepError as e:
             if e.api_code == TWITTER_PAGE_DOES_NOT_EXISTS_ERROR:
@@ -90,7 +90,7 @@ class ResponseBotClient(object):
         :return: Tweet object. None if not found
         """
         try:
-            return Tweet(self._client.get_status(id)._json)
+            return Tweet(self._client.get_status(id=id)._json)
         except TweepError as e:
             if e.api_code == TWITTER_TWEET_NOT_FOUND_ERROR:
                 return None
@@ -104,7 +104,7 @@ class ResponseBotClient(object):
         :return: User object. None if not found
         """
         try:
-            return User(self._client.get_user(id)._json)
+            return User(self._client.get_user(user_id=id)._json)
         except TweepError as e:
             if e.api_code == TWITTER_USER_NOT_FOUND_ERROR:
                 return None
@@ -118,7 +118,7 @@ class ResponseBotClient(object):
         :return: True if success, False otherwise
         """
         try:
-            self._client.destroy_status(id)
+            self._client.destroy_status(id=id)
             return True
         except TweepError as e:
             if e.api_code in [TWITTER_PAGE_DOES_NOT_EXISTS_ERROR, TWITTER_DELETE_OTHER_USER_TWEET]:
@@ -134,10 +134,21 @@ class ResponseBotClient(object):
         :return: user that are followed
         """
         try:
-            return User(self._client.create_friendship(user_id, follow=notify)._json)
+            return User(self._client.create_friendship(user_id=user_id, follow=notify)._json)
         except TweepError as e:
             if e.api_code in [TWITTER_ACCOUNT_SUSPENDED_ERROR]:
                 return self.get_user(user_id)
+            raise APIError(str(e))
+
+    def unfollow(self, user_id):
+        """
+        Follow a user.
+        :param user_id: ID of the user in question
+        :return: The user that were unfollowed
+        """
+        try:
+            return User(self._client.destroy_friendship(user_id=user_id)._json)
+        except TweepError as e:
             raise APIError(str(e))
 
     ###################################################################################

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # - MAJOR version when they make incompatible API changes,
     # - MINOR version when they add functionality in a backwards-compatible manner, and
     # - MAINTENANCE version when they make backwards-compatible bug fixes.
-    version='0.2.4',
+    version='0.2.5',
 
     description='Automatically response to any tweets mentioning you',
 

--- a/tests/unit_tests/test_tweet_client.py
+++ b/tests/unit_tests/test_tweet_client.py
@@ -42,7 +42,7 @@ class TweetClientTestCase(TestCase):
 
         tweet = self.client.tweet('some text')
 
-        self.real_client.update_status.assert_called_once_with('some text')
+        self.real_client.update_status.assert_called_once_with(status='some text')
         self.assertEqual(tweet.some_key, 'some value')
 
     def test_get_tweet(self):
@@ -52,7 +52,7 @@ class TweetClientTestCase(TestCase):
 
         tweet = self.client.get_tweet(123)
 
-        self.real_client.get_status.assert_called_once_with(123)
+        self.real_client.get_status.assert_called_once_with(id=123)
         self.assertEqual(tweet.some_key, 'some value')
 
     def test_get_non_existent_tweet(self):
@@ -63,7 +63,7 @@ class TweetClientTestCase(TestCase):
 
         tweet = self.client.get_tweet(123)
 
-        self.real_client.get_status.assert_called_once_with(123)
+        self.real_client.get_status.assert_called_once_with(id=123)
         self.assertIsNone(tweet)
 
     def test_get_tweet_encounter_error(self):
@@ -80,7 +80,7 @@ class TweetClientTestCase(TestCase):
 
         user = self.client.get_user(123)
 
-        self.real_client.get_user.assert_called_once_with(123)
+        self.real_client.get_user.assert_called_once_with(user_id=123)
         self.assertEqual(user.some_key, 'some value')
 
     def test_get_non_existent_user(self):
@@ -91,7 +91,7 @@ class TweetClientTestCase(TestCase):
 
         user = self.client.get_user(123)
 
-        self.real_client.get_user.assert_called_once_with(123)
+        self.real_client.get_user.assert_called_once_with(user_id=123)
         self.assertIsNone(user)
 
     def test_get_user_encounter_error(self):
@@ -124,7 +124,7 @@ class TweetClientTestCase(TestCase):
 
         result = self.client.remove_tweet(123)
 
-        self.real_client.destroy_status.assert_called_once_with(123)
+        self.real_client.destroy_status.assert_called_once_with(id=123)
         self.assertTrue(result)
 
     def test_remove_non_existent_tweet(self):
@@ -135,7 +135,7 @@ class TweetClientTestCase(TestCase):
 
         result = self.client.remove_tweet(123)
 
-        self.real_client.destroy_status.assert_called_once_with(123)
+        self.real_client.destroy_status.assert_called_once_with(id=123)
         self.assertFalse(result)
 
     def test_remove_others_tweet(self):
@@ -146,7 +146,7 @@ class TweetClientTestCase(TestCase):
 
         result = self.client.remove_tweet(123)
 
-        self.real_client.destroy_status.assert_called_once_with(123)
+        self.real_client.destroy_status.assert_called_once_with(id=123)
         self.assertFalse(result)
 
     def test_remove_tweet_encounter_error(self):
@@ -161,7 +161,7 @@ class TweetClientTestCase(TestCase):
 
         result = self.client.retweet(123)
 
-        self.real_client.retweet.assert_called_once_with(123)
+        self.real_client.retweet.assert_called_once_with(id=123)
         self.assertTrue(result)
 
     def test_retweet_non_existent_tweet(self):
@@ -170,7 +170,7 @@ class TweetClientTestCase(TestCase):
 
         result = self.client.retweet(123)
 
-        self.real_client.retweet.assert_called_once_with(123)
+        self.real_client.retweet.assert_called_once_with(id=123)
         self.assertFalse(result)
 
     def test_retweet_encounter_error(self):
@@ -185,7 +185,7 @@ class TweetClientTestCase(TestCase):
 
         user = self.client.follow(123, notify=True)
 
-        self.real_client.create_friendship.assert_called_once_with(123, follow=True)
+        self.real_client.create_friendship.assert_called_once_with(user_id=123, follow=True)
         self.assertEqual(user.some_key, 'some value')
 
     def test_follow_user_403(self):
@@ -195,13 +195,26 @@ class TweetClientTestCase(TestCase):
 
         user = self.client.follow(123, notify=True)
 
-        self.real_client.create_friendship.assert_called_once_with(123, follow=True)
+        self.real_client.create_friendship.assert_called_once_with(user_id=123, follow=True)
         self.assertEqual(user.some_key, 'some value')
 
     def test_follow_user_unknown_exception(self):
         self.real_client.create_friendship = MagicMock(side_effect=TweepError(reason='unknown'))
 
         self.assertRaises(APIError, self.client.follow, 123)
+
+    def test_unfollow_user(self):
+        self.real_client.destroy_friendship = MagicMock(return_value=MagicMock(_json={'some_key': 'some value'}))
+
+        user = self.client.unfollow(123)
+
+        self.real_client.destroy_friendship.assert_called_once_with(user_id=123)
+        self.assertEqual(user.some_key, 'some value')
+
+    def test_unfollow_non_existent_user(self):
+        self.real_client.destroy_friendship = MagicMock(side_effect=TweepError(reason='page not exists', api_code=34))
+
+        self.assertRaises(APIError, self.client.unfollow, 123)
 
     def test_create_list(self):
         api_return = self.check_api_call_success(


### PR DESCRIPTION
## Description
- Add unfollow utility method for `TweetClient`
## How to test
- Calling `client.unfollow(<user_id>)` should makes the authenticated user (your bot user) unfollow the user with the specified ID
