### PR TITLE
[b] fix decorator prevent docstring generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click==6.6
 coverage==4.0.3
+decorator==4.0.9
 oauthlib==1.0.3
 pluggy==0.3.1
 py==1.4.31

--- a/responsebot/responsebot_client.py
+++ b/responsebot/responsebot_client.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+from decorator import decorate
 from tweepy.error import TweepError, RateLimitError
 
 from responsebot.common.constants import TWITTER_PAGE_DOES_NOT_EXISTS_ERROR, TWITTER_TWEET_NOT_FOUND_ERROR, \
@@ -25,15 +26,15 @@ from responsebot.utils.tweepy import tweepy_list_to_json
 
 
 def api_error_handle(func):
-    def func_wrapper(*args, **kwargs):
+    def func_wrapper(f, *args, **kwargs):
         try:
-            return func(*args, **kwargs)
+            return f(*args, **kwargs)
         except RateLimitError as e:
             raise APIQuotaError(str(e))
         except TweepError as e:
             raise APIError(str(e))
 
-    return func_wrapper
+    return decorate(func, func_wrapper)
 
 class ResponseBotClient(object):
     """

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # - MAJOR version when they make incompatible API changes,
     # - MINOR version when they add functionality in a backwards-compatible manner, and
     # - MAINTENANCE version when they make backwards-compatible bug fixes.
-    version='0.2.5',
+    version='0.2.6',
 
     description='Automatically response to any tweets mentioning you',
 
@@ -33,6 +33,7 @@ setup(
         'python-dotenv',
         'python-dateutil',
         'future',
+        'decorator',
     ],
 
     # Settings for testing purpose


### PR DESCRIPTION
## Description
- Functions with decorator won't generate proper docstring
## How to test
- After this PR is merged and publish to PyPi, list-related API helpers should have proper docstring on [readthedocs](http://responsebot.readthedocs.io/en/latest/reference/responsebot.responsebot_client.html)
