### PR TITLE
[f] post tweet as reply option

### DIFF
--- a/responsebot/responsebot_client.py
+++ b/responsebot/responsebot_client.py
@@ -59,14 +59,14 @@ class ResponseBotClient(object):
             self._current_user = User(self._client.me()._json)
         return self._current_user
 
-    def tweet(self, text):
+    def tweet(self, text, in_reply_to=None):
         """
         Post a new tweet.
-
         :param text: the text to post
+        :param in_reply_to: The ID of the tweet to reply to
         :return: Tweet object
         """
-        return Tweet(self._client.update_status(status=text)._json)
+        return Tweet(self._client.update_status(status=text, in_reply_to_status_id=in_reply_to)._json)
 
     def retweet(self, id):
         """

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # - MAJOR version when they make incompatible API changes,
     # - MINOR version when they add functionality in a backwards-compatible manner, and
     # - MAINTENANCE version when they make backwards-compatible bug fixes.
-    version='0.2.6',
+    version='0.2.7',
 
     description='Automatically response to any tweets mentioning you',
 

--- a/tests/unit_tests/test_tweet_client.py
+++ b/tests/unit_tests/test_tweet_client.py
@@ -42,7 +42,17 @@ class TweetClientTestCase(TestCase):
 
         tweet = self.client.tweet('some text')
 
-        self.real_client.update_status.assert_called_once_with(status='some text')
+        self.real_client.update_status.assert_called_once_with(status='some text', in_reply_to_status_id=None)
+        self.assertEqual(tweet.some_key, 'some value')
+
+    def test_reply(self):
+        self.real_client.update_status = MagicMock(return_value=MagicMock(_json={
+            'some_key': 'some value',
+        }))
+
+        tweet = self.client.tweet('some text', in_reply_to=123)
+
+        self.real_client.update_status.assert_called_once_with(status='some text', in_reply_to_status_id=123)
         self.assertEqual(tweet.some_key, 'some value')
 
     def test_get_tweet(self):


### PR DESCRIPTION
## Description
- Allow posting tweet as reply (will show up in 'View Conversation' on Twitter user interaface)
## How to test
- Tweet some tweet to your bot from user A
- Post a tweet mentioning the user A's screen name with `in_reply_to` param as his user ID, e.g.

``` python
client.tweet("@userA whatsup", in_reply_to=<user_id>)
```
- On user A and your bot's Twitter page, his tweets and yours should be group into a conversation
