### PR TITLE
[f] Handle post tweet error cases in ResponseBot

### DIFF
--- a/responsebot/common/constants.py
+++ b/responsebot/common/constants.py
@@ -19,9 +19,13 @@ TWITTER_TWEET_NOT_FOUND_ERROR = 144
 TWITTER_DELETE_OTHER_USER_TWEET = 183
 TWITTER_ACCOUNT_SUSPENDED_ERROR = 64
 TWITTER_USER_IS_NOT_LIST_MEMBER_SUBSCRIBER = 109
+TWITTER_DUPLICATED_TWEET_ERROR = 187
 
 
 # Twitter non-tweet events
 TWITTER_NON_TWEET_EVENTS = ['access_revoked', 'block', 'unblock', 'favorite', 'unfavorite', 'follow', 'unfollow',
         'list_created', 'list_destroyed', 'list_updated', 'list_member_added', 'list_member_removed',
         'list_user_subscribed', 'list_user_unsubscribed', 'quoted_tweet', 'user_update']
+
+# Other Twitter constants
+TWITTER_CHARACTER_LIMIT = 140

--- a/responsebot/common/exceptions.py
+++ b/responsebot/common/exceptions.py
@@ -69,3 +69,15 @@ class UserHandlerError(ResponseBotError):
     def __init__(self, user_exception, msg='Error from user handler', *args, **kwargs):
         super(UserHandlerError, self).__init__(msg, *args, **kwargs)
         self.__cause__ = user_exception
+
+
+class TweetError(ResponseBotError):
+    """
+    Error to indicate some violation of Twitter's tweet constraints (max characters, etc.)
+    """
+    def __init__(self, reason, *args, **kwargs):
+        super(TweetError, self).__init__(*args, **kwargs)
+        self.reason = reason
+
+    def __str__(self):
+        return self.reason

--- a/responsebot/responsebot_client.py
+++ b/responsebot/responsebot_client.py
@@ -19,8 +19,8 @@ from tweepy.error import TweepError, RateLimitError
 
 from responsebot.common.constants import TWITTER_PAGE_DOES_NOT_EXISTS_ERROR, TWITTER_TWEET_NOT_FOUND_ERROR, \
     TWITTER_USER_NOT_FOUND_ERROR, TWITTER_DELETE_OTHER_USER_TWEET, TWITTER_ACCOUNT_SUSPENDED_ERROR,\
-    TWITTER_USER_IS_NOT_LIST_MEMBER_SUBSCRIBER
-from responsebot.common.exceptions import APIError, APIQuotaError
+    TWITTER_USER_IS_NOT_LIST_MEMBER_SUBSCRIBER, TWITTER_CHARACTER_LIMIT, TWITTER_DUPLICATED_TWEET_ERROR
+from responsebot.common.exceptions import APIError, APIQuotaError, TweetError
 from responsebot.models import Tweet, User, List
 from responsebot.utils.tweepy import tweepy_list_to_json
 
@@ -64,9 +64,17 @@ class ResponseBotClient(object):
         Post a new tweet.
         :param text: the text to post
         :param in_reply_to: The ID of the tweet to reply to
+        :raise TweetError: if the tweet exceeds Twitter's character limit or the tweet is duplicated
         :return: Tweet object
         """
-        return Tweet(self._client.update_status(status=text, in_reply_to_status_id=in_reply_to)._json)
+        if len(text) > TWITTER_CHARACTER_LIMIT:
+            raise TweetError(reason="Message exceeds Twitter's character limit")
+
+        try:
+            return Tweet(self._client.update_status(status=text, in_reply_to_status_id=in_reply_to)._json)
+        except TweepError as e:
+            if e.api_code == TWITTER_DUPLICATED_TWEET_ERROR:
+                raise TweetError(reason='Duplicated tweet')
 
     def retweet(self, id):
         """

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # - MAJOR version when they make incompatible API changes,
     # - MINOR version when they add functionality in a backwards-compatible manner, and
     # - MAINTENANCE version when they make backwards-compatible bug fixes.
-    version='0.2.7',
+    version='0.2.8',
 
     description='Automatically response to any tweets mentioning you',
 


### PR DESCRIPTION
## Description
- Handle silently failed errors according to `tweepy` [docs](http://tweepy.readthedocs.io/en/v3.5.0/api.html#status-methods)
## How to test
- Try to tweet a tweet with more than 140 characters or is a duplicated tweet should raise TweetError
