### PR TITLE
[b] Remove manual handling of Twitter character limit error due to inaccuracy

### DIFF
--- a/responsebot/common/constants.py
+++ b/responsebot/common/constants.py
@@ -19,13 +19,9 @@ TWITTER_TWEET_NOT_FOUND_ERROR = 144
 TWITTER_DELETE_OTHER_USER_TWEET = 183
 TWITTER_ACCOUNT_SUSPENDED_ERROR = 64
 TWITTER_USER_IS_NOT_LIST_MEMBER_SUBSCRIBER = 109
-TWITTER_DUPLICATED_TWEET_ERROR = 187
 
 
 # Twitter non-tweet events
 TWITTER_NON_TWEET_EVENTS = ['access_revoked', 'block', 'unblock', 'favorite', 'unfavorite', 'follow', 'unfollow',
-        'list_created', 'list_destroyed', 'list_updated', 'list_member_added', 'list_member_removed',
-        'list_user_subscribed', 'list_user_unsubscribed', 'quoted_tweet', 'user_update']
-
-# Other Twitter constants
-TWITTER_CHARACTER_LIMIT = 140
+    'list_created', 'list_destroyed', 'list_updated', 'list_member_added', 'list_member_removed',
+    'list_user_subscribed', 'list_user_unsubscribed', 'quoted_tweet', 'user_update']

--- a/responsebot/common/exceptions.py
+++ b/responsebot/common/exceptions.py
@@ -69,15 +69,3 @@ class UserHandlerError(ResponseBotError):
     def __init__(self, user_exception, msg='Error from user handler', *args, **kwargs):
         super(UserHandlerError, self).__init__(msg, *args, **kwargs)
         self.__cause__ = user_exception
-
-
-class TweetError(ResponseBotError):
-    """
-    Error to indicate some violation of Twitter's tweet constraints (max characters, etc.)
-    """
-    def __init__(self, reason, *args, **kwargs):
-        super(TweetError, self).__init__(*args, **kwargs)
-        self.reason = reason
-
-    def __str__(self):
-        return self.reason

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # - MAJOR version when they make incompatible API changes,
     # - MINOR version when they add functionality in a backwards-compatible manner, and
     # - MAINTENANCE version when they make backwards-compatible bug fixes.
-    version='0.2.8',
+    version='0.2.9',
 
     description='Automatically response to any tweets mentioning you',
 


### PR DESCRIPTION
## Description
- Twitter count character limit AFTER shorten URLs, hence our inaccuracy
- Remove redundant constants & errors
## How to test
- Send a tweet with an URL that in total (text + URL) exceeds 140 characters but the text alone is less than 140 characters (~100 characters is fine). An APIError should NOT be raised.
- Send a tweet with text alone exceeds 140 characters. An APIError should be raised.
